### PR TITLE
feat: Enable keyless signing of the images

### DIFF
--- a/.github/workflows/Build_And_Publish_Docker_Images.yml
+++ b/.github/workflows/Build_And_Publish_Docker_Images.yml
@@ -6,9 +6,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 env:
   IMAGE_NAME: enalean/bz2tuleap
@@ -16,19 +14,22 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Build image
         run: docker build -t ${{ env.IMAGE_NAME }} --label revision=${{ github.sha }} --label workflow_run_id=${{ github.run_id }} .
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # tag=v3.7.0
       - name: Log into Docker Hub
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u bz2tuleappushbot --password-stdin
       - name: Publish image
         run: docker push ${{ env.IMAGE_NAME }}
       - name: Sign image
-        env:
-          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
         run: |
-          export VAULT_TOKEN=$(curl "$VAULT_ADDR"/v1/auth/approle/login --silent --fail -X POST --data '{"role_id": "${{ secrets.VAULT_ROLE_ID_SIGNING }}", "secret_id": "${{ secrets.VAULT_SECRET_ID_SIGNING }}"}' | jq -r '.auth.client_token')
-          cosign sign --yes --tlog-upload=true --key hashivault://tuleap-additional-tools-signing "$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.IMAGE_NAME }})"
+          cosign sign --yes "$(docker inspect --format='{{index .RepoDigests 0}}' ${{ env.IMAGE_NAME }})"

--- a/.github/workflows/Build_Docker_Image_PR.yml
+++ b/.github/workflows/Build_Docker_Image_PR.yml
@@ -3,13 +3,16 @@ name: Build Docker image
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Build image
         run: docker build -t test-build .

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 
-permissions: read-all
+permissions: {}
 
 on:
   push:
@@ -15,10 +15,14 @@ jobs:
     strategy:
       matrix:
         php: ['8.2', '8.3']
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@2.31.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # 2.31.1
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring,dom


### PR DESCRIPTION
This allow us to not rely on our internal infrastructure. Workflows have been slightly adjusted to be consistent and avoid some footguns.

Part of request #41087